### PR TITLE
allow for alternative 'configure' scripts

### DIFF
--- a/setuptools_cmmi/__init__.py
+++ b/setuptools_cmmi/__init__.py
@@ -22,6 +22,7 @@ logging.basicConfig(filename='setuptools-cmmi.log',level=logging.DEBUG)
 
 KEY_DOWNLOAD_DIR = "download_dir"
 KEY_CONFIG_OPTIONS = "config_options"
+KEY_CONFIG_NAME = "config_name"
 KEY_URL = "url"
 KEY_AUTOGEN = "autogen"
 KEY_PATCH = "patch"
@@ -79,18 +80,20 @@ def cmmi_entry_point(dist, attr, org_values):
                                vars[VAR_PROJECT_DIR] + "/temp_work_cmmi")
 
     try:
+        config_name = values.get(KEY_CONFIG_NAME)
         config_options = values.get(KEY_CONFIG_OPTIONS, '')
         autogen = values.get(KEY_AUTOGEN, '')
 
         LOG.debug("dist: {}".format(dist))
         LOG.debug("attr: {}".format(attr))
         LOG.debug("url: {}".format(url))
+        LOG.debug("config_name: {}".format(config_name))
         LOG.debug("config_options: {}".format(values[KEY_CONFIG_OPTIONS]))
         LOG.debug("destination_dir: {}".format(values[KEY_DEST_DIR]))
 
         download_unpack_file(url, temp_work_dir)
 
-        process_cmmi(dest_dir, temp_work_dir, config_options, autogen)
+        process_cmmi(dest_dir, temp_work_dir, config_options, autogen, config_name)
 
 
     finally:

--- a/setuptools_cmmi/process_cmmi.py
+++ b/setuptools_cmmi/process_cmmi.py
@@ -41,7 +41,7 @@ def _run(root_path, exec_name, description, args):
                                   .format(exec_path, rc))
 
 
-def process_cmmi(dest_dir, temp_source_dir, config_options, autogen):
+def process_cmmi(dest_dir, temp_source_dir, config_options, autogen, config_name=None):
     """Run through the CMMI process with the given parameters."""
     LOG.debug("Making dir {}".format(dest_dir))
     if not os.path.exists(dest_dir):
@@ -55,7 +55,7 @@ def process_cmmi(dest_dir, temp_source_dir, config_options, autogen):
 
         if autogen:
             _run(src_root, autogen, "Autogen")
-        _run(src_root, "configure", "Configure", config_options)
+        _run(src_root, config_name or "configure", "Configure", config_options)
         _run(src_root, "make", "make", None)
         _run(src_root, "make", "make install", "install")
 

--- a/setuptools_cmmi/tests/test_entry_point.py
+++ b/setuptools_cmmi/tests/test_entry_point.py
@@ -1,24 +1,33 @@
 """Unit tests for the main entry point."""
+import pytest
 import setuptools_cmmi
 
-from mock import patch, Mock
+from mock import patch, Mock, ANY
 
 
 TEST_URL = 'http://repo.in.zillow.net/content/groups/public/com/zillow/zpr/freetds/1.00.15/freetds-1.00.15.tar.gz'
 
 @patch("setuptools_cmmi.download_unpack_file")
 @patch("setuptools_cmmi.process_cmmi")
-def test_cmmi_entry_point(mock_process_cmmi, mock_download_unpack_file):
+@pytest.mark.parametrize("values", [
+    {
+        'url': TEST_URL,
+        'config_options': '--prefix=$project_dir/lib/usr',
+        'destination_dir': '$project_dir/lib/usr',
+    },
+    {
+        'url': TEST_URL,
+        'config_options': '--prefix=$project_dir/lib/usr',
+        'config_name': 'overridden_config',
+        'destination_dir': '$project_dir/lib/usr'
+    }
+])
+def test_cmmi_entry_point(mock_process_cmmi, mock_download_unpack_file, values):
     """Test entry point."""
     distribution = Mock()
     attr = 'cmmi'
-    values = {
-          'url': TEST_URL,
-          'config_options': '--prefix=$project_dir/lib/usr',
-          'destination_dir': '$project_dir/lib/usr'
-      }
     setuptools_cmmi.cmmi_entry_point(distribution, attr, values)
 
     # TODO: Add actual test stuff here
-    mock_process_cmmi.assert_called_once()
     mock_download_unpack_file.assert_called_once()
+    mock_process_cmmi.assert_called_with(ANY, ANY, ANY, ANY, values.get('config_name'))


### PR DESCRIPTION
openssl doesn't seem to follow normal convention and names their configure script "Configure" and additionally prefers "Unix-ish" systems to use "config".

> ~/tmp/scratch/latest/openssl-1.0.2n
>  % ./Configure
> Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [experimental-<cipher> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-dso] [no-krb5] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--test-sanity] os/compiler[:flags]
> 
> pick os/compiler from:
> BC-32 BS2000-OSD BSD-generic32 BSD-generic64 BSD-ia64 BSD-sparc64 BSD-sparcv8
> BSD-x86 BSD-x86-elf BSD-x86_64 Cygwin Cygwin-x86_64 DJGPP MPE/iX-gcc OS2-EMX
> OS390-Unix QNX6 QNX6-i386 ReliantUNIX SINIX SINIX-N UWIN VC-CE VC-WIN32
> VC-WIN64A VC-WIN64I aix-cc aix-gcc aix3-cc aix64-cc aix64-gcc android
> android-armv7 android-mips android-x86 aux3-gcc beos-x86-bone beos-x86-r5
> bsdi-elf-gcc cc cray-j90 cray-t3e darwin-i386-cc darwin-ppc-cc darwin64-ppc-cc
> darwin64-x86_64-cc dgux-R3-gcc dgux-R4-gcc dgux-R4-x86-gcc dist gcc hpux-cc
> hpux-gcc hpux-ia64-cc hpux-ia64-gcc hpux-parisc-cc hpux-parisc-cc-o4
> hpux-parisc-gcc hpux-parisc1_1-cc hpux-parisc1_1-gcc hpux-parisc2-cc
> hpux-parisc2-gcc hpux64-ia64-cc hpux64-ia64-gcc hpux64-parisc2-cc
> hpux64-parisc2-gcc hurd-x86 iphoneos-cross irix-cc irix-gcc irix-mips3-cc
> irix-mips3-gcc irix64-mips4-cc irix64-mips4-gcc linux-aarch64
> linux-alpha+bwx-ccc linux-alpha+bwx-gcc linux-alpha-ccc linux-alpha-gcc
> linux-aout linux-armv4 linux-elf linux-generic32 linux-generic64
> linux-ia32-icc linux-ia64 linux-ia64-icc linux-mips32 linux-mips64 linux-ppc
> linux-ppc64 linux-ppc64le linux-sparcv8 linux-sparcv9 linux-x32 linux-x86_64
> linux-x86_64-clang linux-x86_64-icc linux32-s390x linux64-mips64 linux64-s390x
> linux64-sparcv9 mingw mingw64 ncr-scde netware-clib netware-clib-bsdsock
> netware-clib-bsdsock-gcc netware-clib-gcc netware-libc netware-libc-bsdsock
> netware-libc-bsdsock-gcc netware-libc-gcc newsos4-gcc nextstep nextstep3.3
> osf1-alpha-cc osf1-alpha-gcc purify qnx4 rhapsody-ppc-cc sco5-cc sco5-gcc
> solaris-sparcv7-cc solaris-sparcv7-gcc solaris-sparcv8-cc solaris-sparcv8-gcc
> solaris-sparcv9-cc solaris-sparcv9-gcc solaris-x86-cc solaris-x86-gcc
> solaris64-sparcv9-cc solaris64-sparcv9-gcc solaris64-x86_64-cc
> solaris64-x86_64-gcc sunos-gcc tandem-c89 tru64-alpha-cc uClinux-dist
> uClinux-dist64 ultrix-cc ultrix-gcc unixware-2.0 unixware-2.1 unixware-7
> unixware-7-gcc vos-gcc vxworks-mips vxworks-ppc405 vxworks-ppc60x
> vxworks-ppc750 vxworks-ppc750-debug vxworks-ppc860 vxworks-ppcgen
> vxworks-simlinux debug debug-BSD-x86-elf debug-VC-WIN32 debug-VC-WIN64A
> debug-VC-WIN64I debug-ben debug-ben-darwin64 debug-ben-debug
> debug-ben-debug-64 debug-ben-debug-64-clang debug-ben-macos
> debug-ben-macos-gcc46 debug-ben-no-opt debug-ben-openbsd
> debug-ben-openbsd-debug debug-ben-strict debug-bodo debug-darwin-i386-cc
> debug-darwin-ppc-cc debug-darwin64-x86_64-cc debug-geoff32 debug-geoff64
> debug-levitte-linux-elf debug-levitte-linux-elf-extreme
> debug-levitte-linux-noasm debug-levitte-linux-noasm-extreme debug-linux-elf
> debug-linux-elf-noefence debug-linux-generic32 debug-linux-generic64
> debug-linux-ia32-aes debug-linux-pentium debug-linux-ppro debug-linux-x86_64
> debug-linux-x86_64-clang debug-rse debug-solaris-sparcv8-cc
> debug-solaris-sparcv8-gcc debug-solaris-sparcv9-cc debug-solaris-sparcv9-gcc
> debug-steve-opt debug-steve32 debug-steve64 debug-vos-gcc
> 
> NOTE: If in doubt, on Unix-ish systems use './config'.