### PR TITLE
add make_name option to cmmi

### DIFF
--- a/setuptools_cmmi/__init__.py
+++ b/setuptools_cmmi/__init__.py
@@ -23,6 +23,7 @@ logging.basicConfig(filename='setuptools-cmmi.log',level=logging.DEBUG)
 KEY_DOWNLOAD_DIR = "download_dir"
 KEY_CONFIG_OPTIONS = "config_options"
 KEY_CONFIG_NAME = "config_name"
+KEY_MAKEFILE_NAME = "makefile_name"
 KEY_URL = "url"
 KEY_AUTOGEN = "autogen"
 KEY_PATCH = "patch"
@@ -81,6 +82,7 @@ def cmmi_entry_point(dist, attr, org_values):
 
     try:
         config_name = values.get(KEY_CONFIG_NAME)
+        makefile_name = values.get(KEY_MAKEFILE_NAME)
         config_options = values.get(KEY_CONFIG_OPTIONS, '')
         autogen = values.get(KEY_AUTOGEN, '')
 
@@ -88,12 +90,13 @@ def cmmi_entry_point(dist, attr, org_values):
         LOG.debug("attr: {}".format(attr))
         LOG.debug("url: {}".format(url))
         LOG.debug("config_name: {}".format(config_name))
+        LOG.debug("makefile_name: {}".format(makefile_name))
         LOG.debug("config_options: {}".format(values[KEY_CONFIG_OPTIONS]))
         LOG.debug("destination_dir: {}".format(values[KEY_DEST_DIR]))
 
         download_unpack_file(url, temp_work_dir)
 
-        process_cmmi(dest_dir, temp_work_dir, config_options, autogen, config_name)
+        process_cmmi(dest_dir, temp_work_dir, config_options, autogen, config_name, makefile_name)
 
 
     finally:

--- a/setuptools_cmmi/process_cmmi.py
+++ b/setuptools_cmmi/process_cmmi.py
@@ -41,7 +41,7 @@ def _run(root_path, exec_name, description, args):
                                   .format(exec_path, rc))
 
 
-def process_cmmi(dest_dir, temp_source_dir, config_options, autogen, config_name=None, make_name=None):
+def process_cmmi(dest_dir, temp_source_dir, config_options, autogen, config_name=None, makefile_name=None):
     """Run through the CMMI process with the given parameters."""
     LOG.debug("Making dir {}".format(dest_dir))
     if not os.path.exists(dest_dir):
@@ -56,8 +56,8 @@ def process_cmmi(dest_dir, temp_source_dir, config_options, autogen, config_name
         if autogen:
             _run(src_root, autogen, "Autogen")
         _run(src_root, config_name or "configure", "Configure", config_options)
-        _run(src_root, make_name or "make", "make", None)
-        _run(src_root, make_name or "make", "make install", "install")
+        _run(src_root, makefile_name or "make", "make", None)
+        _run(src_root, makefile_name or "make", "make install", "install")
 
 
     finally:

--- a/setuptools_cmmi/process_cmmi.py
+++ b/setuptools_cmmi/process_cmmi.py
@@ -41,7 +41,7 @@ def _run(root_path, exec_name, description, args):
                                   .format(exec_path, rc))
 
 
-def process_cmmi(dest_dir, temp_source_dir, config_options, autogen, config_name=None):
+def process_cmmi(dest_dir, temp_source_dir, config_options, autogen, config_name=None, make_name=None):
     """Run through the CMMI process with the given parameters."""
     LOG.debug("Making dir {}".format(dest_dir))
     if not os.path.exists(dest_dir):
@@ -56,8 +56,8 @@ def process_cmmi(dest_dir, temp_source_dir, config_options, autogen, config_name
         if autogen:
             _run(src_root, autogen, "Autogen")
         _run(src_root, config_name or "configure", "Configure", config_options)
-        _run(src_root, "make", "make", None)
-        _run(src_root, "make", "make install", "install")
+        _run(src_root, make_name or "make", "make", None)
+        _run(src_root, make_name or "make", "make install", "install")
 
 
     finally:

--- a/setuptools_cmmi/tests/test_entry_point.py
+++ b/setuptools_cmmi/tests/test_entry_point.py
@@ -20,6 +20,13 @@ TEST_URL = 'http://repo.in.zillow.net/content/groups/public/com/zillow/zpr/freet
         'config_options': '--prefix=$project_dir/lib/usr',
         'config_name': 'overridden_config',
         'destination_dir': '$project_dir/lib/usr'
+    },
+    {
+        'url': TEST_URL,
+        'config_options': '--prefix=$project_dir/lib/usr',
+        'config_name': 'overridden_config',
+        'makefile_name': 'overridden_make',
+        'destination_dir': '$project_dir/lib/usr'
     }
 ])
 def test_cmmi_entry_point(mock_process_cmmi, mock_download_unpack_file, values):
@@ -30,4 +37,4 @@ def test_cmmi_entry_point(mock_process_cmmi, mock_download_unpack_file, values):
 
     # TODO: Add actual test stuff here
     mock_download_unpack_file.assert_called_once()
-    mock_process_cmmi.assert_called_with(ANY, ANY, ANY, ANY, values.get('config_name'))
+    mock_process_cmmi.assert_called_with(ANY, ANY, ANY, ANY, values.get('config_name'), values.get('makefile_name'))


### PR DESCRIPTION
This will enable the native lib that use a customized builder to build in uranium, test it with C++ boost lib.